### PR TITLE
handle arbitrary arg list

### DIFF
--- a/src/logger_journald_h.erl
+++ b/src/logger_journald_h.erl
@@ -335,7 +335,10 @@ ensure_bytes(V) when is_list(V) ->
         _ -> V
     catch
         error:badarg ->
-            unicode:characters_to_binary(V)
+            try unicode:characters_to_binary(V)
+	    catch error:badarg ->
+	        io_lib:format("~w", [V])
+	    end
     end;
 ensure_bytes(V) when is_integer(V) ->
     integer_to_binary(V);


### PR DESCRIPTION
I have an Elixir app using this library, but was hitting an error when formatting a list of pids:
```
{:error, :badarg, [{:unicode, :characters_to_binary, [[#PID<0.2266.0>]]
```
This should handle that case